### PR TITLE
Fix fail when filetracker runs on separate machine

### DIFF
--- a/sio/workers/runner.py
+++ b/sio/workers/runner.py
@@ -65,8 +65,8 @@ def run(environ):
 
     with TemporaryCwd():
         try:
-            if environ.get('filetracker_url', None):
-                init_instance(environ['filetracker_url'])
+            if environ.get('FILETRACKER_URL', None):
+                init_instance(environ['FILETRACKER_URL'])
             environ = _run_filters('prefilters', environ)
             environ = _add_meta(environ)
             environ = first_entry_point('sio.jobs',


### PR DESCRIPTION
Currently the Filetracker URL env var is declared in uppercase in the `supervisord-conf-vars.conf` file, but is referenced in lowercase in code, because of which it is not retrieved properly. This causes the entire process to break if Filetracker is running on a remote machine.

(PS. Czy bez uprzedniej autoryzacji można wstawiać patche na Gerrita? Próbowałem ale mi nie wychodziło.)