### PR TITLE
Pass input test name to inwer

### DIFF
--- a/sio/executors/inwer.py
+++ b/sio/executors/inwer.py
@@ -32,7 +32,7 @@ def _run_in_executor(environ, command, executor, **kwargs):
 
 
 def _run_inwer(environ, use_sandboxes=False):
-    command = [tempcwd('inwer')]
+    command = [tempcwd('inwer'), environ['in_file_name']]
     if use_sandboxes:
         executor = SupervisedExecutor()
     else:
@@ -48,6 +48,9 @@ def run(environ):
     ``exe_file``: the filetracker path to the program
 
     ``in_file``: the file redirected to the program's stdin
+
+    ``in_file_name``: the name of the input file. It's passed to inwer as
+                        the second argument.
 
     ``use_sandboxes``: if this key equals ``True``, the program is executed
                      in the SupervisedExecutor, otherwise the UnsafeExecutor

--- a/sio/executors/inwer.py
+++ b/sio/executors/inwer.py
@@ -32,7 +32,9 @@ def _run_in_executor(environ, command, executor, **kwargs):
 
 
 def _run_inwer(environ, use_sandboxes=False):
-    command = [tempcwd('inwer'), environ['in_file_name']]
+    command = [tempcwd('inwer')]
+    if 'in_file_name' in environ:
+        command.append(environ['in_file_name'])
     if use_sandboxes:
         executor = SupervisedExecutor()
     else:

--- a/sio/workers/test/sources/inwer_argument.c
+++ b/sio/workers/test/sources/inwer_argument.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        printf("WRONG\nWrong number of arguments");
+        return 1;
+    }
+    if (strcmp(argv[1], "inwer_ok") != 0) {
+        printf("WRONG\nWrong test name");
+        return 1;
+    }
+    printf("OK\n");
+    return 0;
+}

--- a/sio/workers/test/test_executors.py
+++ b/sio/workers/test/test_executors.py
@@ -449,6 +449,7 @@ def test_inwer(inwer, in_file, use_sandboxes, callback):
     with TemporaryCwd():
         env = {
             'in_file': in_file,
+            'in_file_name': os.path.basename(in_file),
             'exe_file': inwer_bin,
             'use_sandboxes': use_sandboxes,
             'inwer_output_limit': SMALL_OUTPUT_LIMIT,

--- a/sio/workers/test/test_executors.py
+++ b/sio/workers/test/test_executors.py
@@ -436,6 +436,8 @@ def _make_inwer_cases():
         yield '/inwer_big_output.c', '/inwer_ok', use_sandboxes, check_inwer_big_output(
             use_sandboxes
         )
+        yield '/inwer_argument.c', '/inwer_ok', use_sandboxes, check_inwer_ok
+        yield '/inwer_argument.c', '/inwer_wrong', use_sandboxes, check_inwer_wrong
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR introduces passing test name to inwer as an argument. This will allow task creators to write inwers that will be able to verify if tests are in correct groups. It is a backwards-compatible change, because inwers shouldn't expect any arguments.

Related: https://github.com/sio2project/oioioi/pull/258