### PR TITLE
Return result percentage as fraction

### DIFF
--- a/sio/executors/checker.py
+++ b/sio/executors/checker.py
@@ -149,3 +149,5 @@ def output_to_fraction(output_str):
             'Invalid checker output, expected float, percent or fraction, got "%s"'
             % output_str
         )
+    except ZeroDivisionError:
+        raise CheckerError('Zero division in checker output "%s"' % output_str)

--- a/sio/executors/checker.py
+++ b/sio/executors/checker.py
@@ -141,24 +141,11 @@ def run(environ, use_sandboxes=True):
 def output_to_fraction(output_str):
     if not output_str:
         return 100, 1
-    output_is_float = float_pattern.match(r"[0-9]+\.[0-9]*", output_str)
-    output_is_percent = percent_pattern.match(r"[0-9]+", output_str)
-    output_is_fraction = fraction_pattern.match(r"[0-9]+\ [0-9]+", output_str)
-    if output_is_float:
-        return float_to_fraction(output_str)
-    elif output_is_percent:
-        return int(output_str), 1
-    elif output_is_fraction:
-        return tuple(output_str.split(" "))
-    else:
+    try:
+        frac = Fraction(output_str)
+        return frac.numerator, frac.denominator
+    except ValueError:
         raise CheckerError(
             'Invalid checker output, expected float, percent or fraction, got "%s"'
             % output_str
         )
-
-
-def float_to_fraction(float_str):
-    nominator = int(''.join(filter(str.isdigit, float_str)))
-    denominator = 10 ** (len(float_str) - float_str.find('.') - 1)
-    return nominator, denominator
-

--- a/sio/executors/checker.py
+++ b/sio/executors/checker.py
@@ -4,6 +4,7 @@ import logging
 import tempfile
 import six
 import re
+from fractions import Fraction
 
 from sio.workers import ft
 from sio.workers.executors import (

--- a/sio/executors/checker.py
+++ b/sio/executors/checker.py
@@ -142,6 +142,8 @@ def run(environ, use_sandboxes=True):
 def output_to_fraction(output_str):
     if not output_str:
         return 100, 1
+    if isinstance(output_str, bytes):
+        output_str = output_str.decode('utf-8')
     try:
         frac = Fraction(output_str)
         return frac.numerator, frac.denominator
@@ -152,3 +154,5 @@ def output_to_fraction(output_str):
         )
     except ZeroDivisionError:
         raise CheckerError('Zero division in checker output "%s"' % output_str)
+    except TypeError:
+        raise CheckerError('Invalid checker output "%s"' % output_str)

--- a/sio/workers/test/sources/chk-float.c
+++ b/sio/workers/test/sources/chk-float.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+/* Simple unsafe checker with buffer overflow */
+
+int main(int argc, char **argv) {
+    char buf[255], buf2[255];
+    FILE* fdi = fopen(argv[1], "r");
+    FILE* fdo = fopen(argv[2], "r");
+    FILE* fdh = fopen(argv[3], "r");
+    fscanf(fdh, "%s", buf);
+    fscanf(fdo, "%s", buf2);
+    if (strcmp(buf, buf2) == 0)
+        puts("OK\nOK\n42.00");
+    else
+        puts("WRONG");
+    return 0;
+}

--- a/sio/workers/test/sources/chk-fraction.c
+++ b/sio/workers/test/sources/chk-fraction.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+/* Simple unsafe checker with buffer overflow */
+
+int main(int argc, char **argv) {
+    char buf[255], buf2[255];
+    FILE* fdi = fopen(argv[1], "r");
+    FILE* fdo = fopen(argv[2], "r");
+    FILE* fdh = fopen(argv[3], "r");
+    fscanf(fdh, "%s", buf);
+    fscanf(fdo, "%s", buf2);
+    if (strcmp(buf, buf2) == 0)
+        puts("OK\nOK\n84 2");
+    else
+        puts("WRONG");
+    return 0;
+}

--- a/sio/workers/test/sources/chk-fraction.c
+++ b/sio/workers/test/sources/chk-fraction.c
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     fscanf(fdh, "%s", buf);
     fscanf(fdo, "%s", buf2);
     if (strcmp(buf, buf2) == 0)
-        puts("OK\nOK\n84 2");
+        puts("OK\nOK\n84/2");
     else
         puts("WRONG");
     return 0;

--- a/sio/workers/test/test_executors.py
+++ b/sio/workers/test/test_executors.py
@@ -350,7 +350,7 @@ def test_truncating_output():
 def _make_untrusted_checkers_cases():
     def ok_42(env):
         res_ok(env)
-        eq_(42, int(env['result_percentage']))
+        eq_(42, int(env['result_percentage'][0] / env['result_percentage'][1]))
 
     # Test if unprotected execution allows for return code 1
     yield '/chk-rtn1.c', None, False, None

--- a/sio/workers/test/test_executors.py
+++ b/sio/workers/test/test_executors.py
@@ -839,11 +839,33 @@ def test_execute():
 def test_checker_percentage_parsing():
     eq_(output_to_fraction('42'), (42, 1))
     eq_(output_to_fraction('42.123'), (42123, 1000))
-    eq_(output_to_fraction('42 21'), (42, 21))
+    eq_(output_to_fraction('42/21'), (2, 1))
+    eq_(output_to_fraction('42.'), (42, 1))
+    eq_(output_to_fraction('007'), (7, 1))
+    eq_(output_to_fraction('007/0042'), (1, 6))
+    eq_(output_to_fraction('1e5'), (100000, 1))
 
-    with pytest.raises(CheckerError):
-        output_to_fraction('42  2')
-    with pytest.raises(CheckerError):
+    with raises(CheckerError):
+        output_to_fraction('42 2')
+    with raises(CheckerError):
         output_to_fraction('42,2')
-    with pytest.raises(CheckerError):
+    with raises(CheckerError):
         output_to_fraction('42 2 1')
+    with raises(CheckerError):
+        output_to_fraction('42/2/1')
+    with raises(CheckerError):
+        output_to_fraction('42/2.1')
+    with raises(CheckerError):
+        output_to_fraction('')
+    with raises(CheckerError):
+        output_to_fraction('42/')
+    with raises(CheckerError):
+        output_to_fraction('/42')
+    with raises(CheckerError):
+        output_to_fraction('/')
+    with raises(CheckerError):
+        output_to_fraction('42/0')
+    with raises(CheckerError):
+        output_to_fraction('abc')
+    with raises(CheckerError):
+        output_to_fraction('42/abc')

--- a/sio/workers/test/test_executors.py
+++ b/sio/workers/test/test_executors.py
@@ -844,6 +844,7 @@ def test_checker_percentage_parsing():
     eq_(output_to_fraction('007'), (7, 1))
     eq_(output_to_fraction('007/0042'), (1, 6))
     eq_(output_to_fraction('1e5'), (100000, 1))
+    eq_(output_to_fraction(''), (100, 1))
 
     with pytest.raises(CheckerError):
         output_to_fraction('42 2')
@@ -855,8 +856,7 @@ def test_checker_percentage_parsing():
         output_to_fraction('42/2/1')
     with pytest.raises(CheckerError):
         output_to_fraction('42/2.1')
-    with pytest.raises(CheckerError):
-        output_to_fraction('')
+
     with pytest.raises(CheckerError):
         output_to_fraction('42/')
     with pytest.raises(CheckerError):

--- a/sio/workers/test/test_executors.py
+++ b/sio/workers/test/test_executors.py
@@ -845,27 +845,27 @@ def test_checker_percentage_parsing():
     eq_(output_to_fraction('007/0042'), (1, 6))
     eq_(output_to_fraction('1e5'), (100000, 1))
 
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('42 2')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('42,2')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('42 2 1')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('42/2/1')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('42/2.1')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('42/')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('/42')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('/')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('42/0')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('abc')
-    with raises(CheckerError):
+    with pytest.raises(CheckerError):
         output_to_fraction('42/abc')


### PR DESCRIPTION
Now sioworkers will return a tuple which represents a fraction of the points that the checker assigned. There are 3 formats:
- the old one: `[0-9]+`
- float: `[0-9]+.[0-9]+`
- fraction `[0-9]+ [0-9]+`

This will allow more precise point assignment. Related https://github.com/sio2project/oioioi/pull/332