### PR TITLE
Bump sio2jail version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "sioworkers",
-    version = '1.5.0',
+    version = '1.5.1',
     author = "SIO2 Project Team",
     author_email = 'sio2@sio2project.mimuw.edu.pl',
     description = "Programming contest judging infrastructure",

--- a/sio/workers/executors.py
+++ b/sio/workers/executors.py
@@ -603,7 +603,7 @@ class Sio2JailExecutor(SandboxExecutor):
     REAL_TIME_LIMIT_ADDEND = 1000  # (in ms)
 
     def __init__(self):
-        super(Sio2JailExecutor, self).__init__('sio2jail_exec-sandbox')
+        super(Sio2JailExecutor, self).__init__('sio2jail_exec-sandbox-1.4.4')
 
     def _execute(self, command, **kwargs):
         options = []


### PR DESCRIPTION
With the old version tests for interactive via IO didn't work