### PR TITLE
Switch cpu-exec to real-time-measuring sio2jail

### DIFF
--- a/sio/executors/executor.py
+++ b/sio/executors/executor.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 from sio.executors import common, interactive_common
-from sio.workers.executors import SupervisedExecutor
+from sio.workers.executors import RealTimeSio2JailExecutor
 
 
 def run(environ):
-    return common.run(environ, SupervisedExecutor())
+    return common.run(environ, RealTimeSio2JailExecutor())
 
 def interactive_run(environ):
-    return interactive_common.run(environ, SupervisedExecutor())
+    return interactive_common.run(environ, RealTimeSio2JailExecutor())

--- a/sio/workers/file_runners.py
+++ b/sio/workers/file_runners.py
@@ -3,6 +3,7 @@ from sio.workers.executors import (
     UnprotectedExecutor,
     DetailedUnprotectedExecutor,
     Sio2JailExecutor,
+    RealTimeSio2JailExecutor,
     SupervisedExecutor,
     PRootExecutor,
 )
@@ -95,6 +96,7 @@ class Executable(LanguageModeWrapper):
         DetailedUnprotectedExecutor,
         PRootExecutor,
         Sio2JailExecutor,
+        RealTimeSio2JailExecutor,
         SupervisedExecutor,
     )
 

--- a/sio/workers/test/sources/openrw.c
+++ b/sio/workers/test/sources/openrw.c
@@ -1,4 +1,5 @@
 #include <fcntl.h>
+#include <unistd.h>
 
 int main() {
     char ch[] = "1337";


### PR DESCRIPTION
This PR upstreams the switch to sio2jail for safely measuring real time, which was on prod for a few years.
The only issue is that the docker setup provided in OIOIOI does not work with sio2jail, but that should be addressed separately.

To actually use this in OIOIOI on simple (non-acm?) contests, one will need to set `USE_UNSAFE_EXEC = False` and `DEFAULT_SAFE_EXECUTION_MODE = "cpu"` in `settings.py`.
Here's a release for testing: http://github.com/otargowski/sioworkers/archive/refs/tags/rt-s2j-2.tar.gz